### PR TITLE
remove local variables as they are not posix

### DIFF
--- a/etch
+++ b/etch
@@ -85,7 +85,7 @@ decrypt() {
 while test $# -ne 0; do
   arg=$1; shift
   case $arg in
-    -e|--encrypt) encrypt $@; exit;;
+    -e|--encrypt) encrypt $@; exit ;;
     -d|--decrypt) decrypt $@; exit ;;
     -h|--help) help; exit ;;
     *)

--- a/etch
+++ b/etch
@@ -69,11 +69,14 @@ decrypt() {
   # If input file exists, decrypt and print
   if [ -f "$NAME" ]; then
     command openssl enc -d -aes256 -in $NAME
-    printf "\n"
+    if [ $? -eq 0 ]; then
+      exit 0
+    else
+      exit -1
+    fi
   else
     abort "no such file: $NAME"
   fi
-
 }
 
 #

--- a/etch
+++ b/etch
@@ -38,40 +38,40 @@ abort() {
 # encrypt
 #
 encrypt() {
-  local NAME="$1"
+  # $1 is the filename
 
   # Check if we have a file arg
-  if [ ! $NAME ]; then
+  if [ ! $1 ]; then
     abort "-e option requires a file to encrypt"
   fi
   # Check source file exists
-  if [ ! -f "$NAME" ]; then
-    abort "no such file: $NAME"
+  if [ ! -f "$1" ]; then
+    abort "no such file: $1"
   fi
   # Check if destination file exists, if so abort.
-  if [ -f "$NAME-aes256" ]; then
-    abort "encrypted file already exists: $NAME-aes256"
+  if [ -f "$1-aes256" ]; then
+    abort "encrypted file already exists: $1-aes256"
   fi
 
-  command openssl enc -e -aes256 -in $NAME -out $NAME-aes256
+  command openssl enc -e -aes256 -in $1 -out $1-aes256
 }
 
 #
 # decrypt & Print to stdout
 #
 decrypt() {
-  local NAME="$1"
+  # $1 is the filename
 
   # Check if we have a file arg
-  if [ ! $NAME ]; then
+  if [ ! $1 ]; then
     abort "-d option requires a file to decrypt"
   fi
   # If input file exists, decrypt and print
-  if [ -f "$NAME" ]; then
-    command openssl enc -d -aes256 -in $NAME
+  if [ -f "$1" ]; then
+    command openssl enc -d -aes256 -in $1
     printf "\n"
   else
-    abort "no such file: $NAME"
+    abort "no such file: $1"
   fi
 
 }

--- a/readme.md
+++ b/readme.md
@@ -32,19 +32,5 @@ etch -d ~/secret.txt-aes256
 You'll be prompted for the passphrase used to encrypt the file before the
 decrypted data is printed to `stdout`.
 
-### Convert a file
-`etch` doesn't delete or overwrite any files, and has no 'conversion'
-features.
-
-You might want to do something like this to convert a file:
-````
-etch -e secret.txt && rm secret.txt
-````
-
-To convert an encrypted file back, you might want to do something like this:
-````
-touch secret.txt && etch -d secret.txt-aes256 >> secret.txt && rm secret.txt-aes256
-````
-
 ### License
 MIT License


### PR DESCRIPTION
The `local` keyword is not supported by posix. As the variable $1 is
local to each invocation of the program, it makes more sense to use this
rather than polluting the global scope on some systems. Added a comment
to clarify usage in code.